### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Stories in Ready](https://badge.waffle.io/apinf/api-umbrella-dashboard.png?label=ready&title=Ready)](https://waffle.io/apinf/api-umbrella-dashboard)
 # API Umbrella Dashboard
 Dashboard component for the open-source API management platform [API Umbrella](http://nrel.github.io/api-umbrella/).


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/apinf/api-umbrella-dashboard

This was requested by a real person (user brylie) on waffle.io, we're not trying to spam you.