### PR TITLE
field title fix

### DIFF
--- a/both/catalogue.js
+++ b/both/catalogue.js
@@ -10,7 +10,7 @@ TabularTables.ApiTable = new Tabular.Table({
   collection: ApiBackends,
   columns: [
     {data: "name", title: "Name"},
-    {data: "host", title: "Backend host"},
+    {data: "backend_host", title: "Backend host"},
     {tmpl: Meteor.isClient && Template.favourite, title: "Bookmark"}
   ]
 });


### PR DESCRIPTION
Missing value in catalogue view for `backend_host` in now in place.
@apinf/developers review this hotfix. #372 - related issue.