### PR TITLE
Hotfix for a bug 'Data not fould' closes - #582, #583, #585

### DIFF
--- a/client/views/dashboard/charts/charts.js
+++ b/client/views/dashboard/charts/charts.js
@@ -81,18 +81,21 @@ Template.chartsLayout.created = function () {
   instance.getDashboardData = function (input) {
 
     // calling method that returns data from elastic search
-    Meteor.call("getChartData", input, function (err, data) {
+    Meteor.call("getChartData", input, function (err, response) {
 
       // error checking
-      if (err) {
+      if (err || !response.isOk) {
+
+        // Gets custom error message from i18n
+        var errorMessage = TAPi18n.__("filterData-Title");
 
         // removing loading state once loaded
-        $('#loadingState').html("Data is not found! Please check your filtering options.");
+        $('#loadingState').html(errorMessage);
 
       } else {
 
         // gets to level in object with needed data
-        var dashboardData = data.hits.hits;
+        var dashboardData = response.searchResults.hits.hits;
 
         // parse the returned data for DC
         var parsedChartData = instance.parseChartData(dashboardData);

--- a/client/views/dashboard/charts/charts.js
+++ b/client/views/dashboard/charts/charts.js
@@ -87,8 +87,7 @@ Template.chartsLayout.created = function () {
       if (err) {
 
         // removing loading state once loaded
-        $('#loadingState').html("Loaded");
-        alert("Data is not found!");
+        $('#loadingState').html("Data is not found! Please check your filtering options.");
 
       } else {
 

--- a/client/views/dashboard/charts/charts.js
+++ b/client/views/dashboard/charts/charts.js
@@ -83,6 +83,12 @@ Template.chartsLayout.created = function () {
     // calling method that returns data from elastic search
     Meteor.call("getChartData", input, function (err, response) {
 
+      // response object:
+      // {
+      //    isOk: Boolean,
+      //    searchResults: Object
+      // }
+
       // error checking
       if (err || !response.isOk) {
 

--- a/client/views/dashboard/charts/charts.js
+++ b/client/views/dashboard/charts/charts.js
@@ -83,14 +83,8 @@ Template.chartsLayout.created = function () {
     // calling method that returns data from elastic search
     Meteor.call("getChartData", input, function (err, response) {
 
-      // response object:
-      // {
-      //    isOk: Boolean,
-      //    searchResults: Object
-      // }
-
       // error checking
-      if (err || !response.isOk) {
+      if (err) {
 
         // Gets custom error message from i18n
         var errorMessage = TAPi18n.__("esData-notFound");
@@ -101,7 +95,7 @@ Template.chartsLayout.created = function () {
       } else {
 
         // gets to level in object with needed data
-        var dashboardData = response.searchResults.hits.hits;
+        var dashboardData = response.hits.hits;
 
         // parse the returned data for DC
         var parsedChartData = instance.parseChartData(dashboardData);

--- a/client/views/dashboard/charts/charts.js
+++ b/client/views/dashboard/charts/charts.js
@@ -93,7 +93,7 @@ Template.chartsLayout.created = function () {
       if (err || !response.isOk) {
 
         // Gets custom error message from i18n
-        var errorMessage = TAPi18n.__("filterData-Title");
+        var errorMessage = TAPi18n.__("esData-notFound");
 
         // removing loading state once loaded
         $('#loadingState').html(errorMessage);

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -153,7 +153,7 @@
 
   /*Charts*/
   /*Error messages*/
-  "esData-notFound": "You have no API usage statistics. Please make some calls with your API Key."
+  "esData-notFound": "You have no API usage statistics. Please make some calls with your API Key.",
   /*Bar chart*/
   "overviewChart-Title": "Overview chart",
   "moveChart-Title": "Chart",

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -1,5 +1,4 @@
 {
-
   /*Config*/
   "configName": "Apinf",
   "configTitle": "Build custom APIs. Fast.",
@@ -28,6 +27,7 @@
   "home-MainTitle": "APINF - API Management Platform",
   "home-SecondaryTitle": "Building a bridge between API owners and users.",
   "Dashboard": "Go to dashboard",
+  
   /*Body*/
   "feature-Section-Heading1": "Are you an API user?",
   "feature-Title1": "Discover APIs",
@@ -154,9 +154,11 @@
   /*Charts*/
   /*Error messages*/
   "esData-notFound": "There are no API usage statistics available.",
+  
   /*Bar chart*/
   "overviewChart-Title": "Overview chart",
   "moveChart-Title": "Chart",
+  
   /*Filter*/
   "filterData-Title": "Filter",
   "filterData-Month": "Month:",
@@ -177,8 +179,10 @@
   "filterData-SelectedOf": "selected out of",
   "filterData-Records": "records",
   "filterData-Reset": "Reset All",
+  
   /*Map*/
   "map-Title": "Map",
+  
   /*Data Table*/
   "dataTable-Title": "Table",
   "dataTable-TimeStamp": "Time stamp",
@@ -203,7 +207,4 @@
   "notFound-Message-Part1": "We could not find the page you were looking for.",
   "notFound-Message-Part2": "Meanwhile, you may",
   "notFound-Message-Part3": "return to a previous page"
-
-
-
 }

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -153,7 +153,7 @@
 
   /*Charts*/
   /*Error messages*/
-  "esData-notFound": "You have no API usage statistics. Please make some calls with your API Key.",
+  "esData-notFound": "There are no API usage statistics available.",
   /*Bar chart*/
   "overviewChart-Title": "Overview chart",
   "moveChart-Title": "Chart",

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -152,6 +152,8 @@
   "feedback-feedbackForm-description": "We welcome problem reports, feature ideas and general comments.",
 
   /*Charts*/
+  /*Error messages*/
+  "esData-notFound": "You have no API usage statistics. Please make some calls with your API Key."
   /*Bar chart*/
   "overviewChart-Title": "Overview chart",
   "moveChart-Title": "Chart",

--- a/server/methods/elasticSearch.js
+++ b/server/methods/elasticSearch.js
@@ -3,6 +3,8 @@ Meteor.methods({
 
     // initialise variables
     var loggedInUser, apiKey, query, searchResults;
+
+    // default value for search status
     var isOk = false;
 
     // get user object
@@ -33,6 +35,7 @@ Meteor.methods({
 
     }
 
+    // New instance of ElasticRest class with query as constructor
     var newSearch = new ElasticRest(
       data.index,
       data.type,
@@ -41,10 +44,17 @@ Meteor.methods({
       data.fields
     );
 
+    // Try catch - if search fails, returns user - friendly status
     try{
+
       searchResults = newSearch.doSearch();
+
+      // Changes "isOk" state to true if "try{}" didn't break before
       isOk = true;
+
     }catch(err){
+
+      // Providing empty object to be returned within "isOk:false" for consistency
       searchResults = {};
     }
 

--- a/server/methods/elasticSearch.js
+++ b/server/methods/elasticSearch.js
@@ -48,7 +48,7 @@ Meteor.methods({
 
     }catch(err){
 
-      // Providing empty object to be returned within "isOk:false" for consistency
+      // Throw a 500 error explaining that the data was not found
       throw new Meteor.Error(500, 'Analytics data is not found.');
     }
 

--- a/server/methods/elasticSearch.js
+++ b/server/methods/elasticSearch.js
@@ -2,9 +2,8 @@ Meteor.methods({
   "getChartData": function (data) {
 
     // initialise variables
-    var loggedInUser;
-    var apiKey;
-    var query;
+    var loggedInUser, apiKey, query, searchResults;
+    var isOk = false;
 
     // get user object
     loggedInUser = Meteor.user();
@@ -31,7 +30,7 @@ Meteor.methods({
           "api_key": apiKey
         }
       }
-      
+
     }
 
     var newSearch = new ElasticRest(
@@ -42,6 +41,16 @@ Meteor.methods({
       data.fields
     );
 
-    return newSearch.doSearch();
+    try{
+      searchResults = newSearch.doSearch();
+      isOk = true;
+    }catch(err){
+      searchResults = {};
+    }
+
+    return {
+      isOk: isOk,
+      searchResults: searchResults
+    };
   }
 });

--- a/server/methods/elasticSearch.js
+++ b/server/methods/elasticSearch.js
@@ -4,9 +4,6 @@ Meteor.methods({
     // initialise variables
     var loggedInUser, apiKey, query, searchResults;
 
-    // default value for search status
-    var isOk = false;
-
     // get user object
     loggedInUser = Meteor.user();
 
@@ -44,23 +41,17 @@ Meteor.methods({
       data.fields
     );
 
-    // Try catch - if search fails, returns user - friendly status
+    // Try catch - if search fails, returns user - friendly error
     try{
 
       searchResults = newSearch.doSearch();
 
-      // Changes "isOk" state to true if "try{}" didn't break before
-      isOk = true;
-
     }catch(err){
 
       // Providing empty object to be returned within "isOk:false" for consistency
-      searchResults = {};
+      throw new Meteor.Error(500, 'Analytics data is not found.');
     }
 
-    return {
-      isOk: isOk,
-      searchResults: searchResults
-    };
+    return searchResults;
   }
 });


### PR DESCRIPTION
@apinf/developers  please review.

Removed nested alert() in chart dashboard. Now, if data was not found user is still notified but data returned from previous query is present.

<img width="753" alt="screen shot 2015-11-11 at 14 32 03" src="https://cloud.githubusercontent.com/assets/2122679/11084626/08f533ce-8881-11e5-9369-70d042017f25.png">
