### PR TITLE
Remove defaultLanguage configuration. Closes #814

### DIFF
--- a/lib/_config/_config.js
+++ b/lib/_config/_config.js
@@ -4,7 +4,6 @@ Config = {
   subtitle: function() {
     return TAPi18n.__('configSubtitle');
   },
-  defaultLanguage: 'en',
   dateFormat: 'D/M/YYYY',
   legal: {
     address: 'Jessnerstrasse 18, 12047 Berlin',

--- a/lib/_config/i18n.js
+++ b/lib/_config/i18n.js
@@ -1,9 +1,0 @@
-Meteor.startup(function() {
-  if (Meteor.isClient) {
-    if (Config.defaultLanguage) {
-      return TAPi18n.setLanguage(Config.defaultLanguage);
-    } else {
-      return TAPi18n.setLanguage('en');
-    }
-  }
-});


### PR DESCRIPTION
Remove the default language setting from Config and startup. TAPi18n auto-detects user locale and sets language, which user can then manually change. I am not sure whether we need/or want a default language override.