### PR TITLE
Cleanup/GitHub onlogin hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "doc": "docs"
   },
   "dependencies": {
+    "github": "^1.2.0",
     "crossfilter": "^1.3.12",
     "d3": "^3.5.17",
     "datatables": "^1.10.12",

--- a/server/accounts.js
+++ b/server/accounts.js
@@ -1,3 +1,5 @@
+import Github from 'github';
+
 Accounts.onCreateUser(function(options, user) {
   // Initialize API Umbrella related variables
   var apiUmbrellaUserObj, response;
@@ -64,7 +66,7 @@ Accounts.onLogin(function(info) {
 
   if ((ref = user.services) != null ? ref.github : void 0) {
     if (user) {
-      github = new GitHub({
+      github = new Github({
         version: '3.0.0',
         timeout: 5000
       });
@@ -84,7 +86,4 @@ Accounts.onLogin(function(info) {
       }
     }
   }
-
-  // Add initial user to admin role
-  Meteor.call('addFirstUserToAdminRole', userId);
 });


### PR DESCRIPTION
Closes #1126 

## Proposed changes
- add Github npm package
- import & use to fix exception
- remove old admin role call from onLogin hook, handled by the package, https://github.com/apinf/meteor-first-user-admin/blob/master/server/accounts.js