### PR TITLE
Add docker-compose.yml for production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ settings.json
 uploads/
 mup.json
 docker/api-umbrella/config/api-umbrella.yml
+docker/apinf/env
+docker/ssl/env
 node_modules/
 packages
 node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 # Based on "MeteorD - Docker Runtime for Meteor Apps for Production Deployments"
-# https://github.com/meteorhacks/meteord
-FROM meteorhacks/meteord:onbuild
+FROM apinf/meteord:onbuild
 
 MAINTAINER apinf <info@apinf.io>

--- a/README.md
+++ b/README.md
@@ -42,19 +42,37 @@ For the ecosystem, we will concentrate on open APIs in the MVP phase. For the AP
 
 ## With Docker
 
-1. Install [Docker Engine for your OS](https://docs.docker.com/engine/installation/)
-2. Run API-umbrella container http://api-umbrella.readthedocs.io/en/latest/getting-started.html#running-with-docker
-3. Obtaining API Key and Authentication token. You can obtain the *Authentication Token* and *API Key* from the API Umbrella platform by following instructions in the [Getting Started](http://apiumbrella.io/docs/getting-started/) and [API Umbrella Admin API](http://apiumbrella.io/docs/admin-api/) documentation.
-4. Run APInf container ```docker run -p 8080:80 -e MONGO_URL=mongodb://localhost:27017/your_db -e MAIL_URL=smtp://some.mailserver.com:25 -e ROOT_URL=http://YOUR_SITE_DOMAIN apinf/apinf:latest```
-5. Configure APInf
+1. Run API-umbrella container http://api-umbrella.readthedocs.io/en/latest/getting-started.html#running-with-docker
+2. Obtaining API Key and Authentication token. You can obtain the *Authentication Token* and *API Key* from the API Umbrella platform by following instructions in the [Getting Started](http://apiumbrella.io/docs/getting-started/) and [API Umbrella Admin API](http://apiumbrella.io/docs/admin-api/) documentation.
+3. Run APInf container ```docker run -p 8080:80 -e MONGO_URL=mongodb://localhost:27017/your_db -e MAIL_URL=smtp://some.mailserver.com:25 -e ROOT_URL=http://YOUR_SITE_DOMAIN apinf/apinf:latest```
+4. Configure APInf
 
-# Configure APInf
+### Configure APInf
 
 Register a new admin account. The first user will become Admin.
 
  1. Signup to the APInf http://YOUR_SITE_DOMAIN/sign-up
  2. Login to the APInf web admin http://YOUR_SITE_DOMAIN/sign-in
  3. Fill APInf settings http://YOUR_SITE_DOMAIN/settings
+
+## With Docker Compose
+1. Create "docker-compose.yml" file on your server and copy content from [docker-compose.yml](https://github.com/apinf/api-umbrella-dashboard/blob/develop/docker-compose.yml).
+2. In the same folder create file "docker/api-umbrella/config/api-umbrella.yml" based on example "docker/api-umbrella/config/api-umbrella.yml.example". ATTENTION: replace "example.com" on YOUR_SITE_DOMAIN for keys "ssl_cert" and "ssl_cert_key".
+3. Create file "docker/apinf/env" based on example "docker/apinf/env.example".
+4. Create file "docker/ssl/env" based on example "docker/ssl/env.example".
+5. Run ```docker-compose up -d```. The first launch of will be slow because (take couple of minutes) of the DH parameter computation and configure Let's Encrypt certificate.
+6. Visit https://YOUR_SITE_DOMAIN:3002/signup/ and fill form for get API Key.
+7. Visit https://YOUR_SITE_DOMAIN:3002/admin/ and click on 'My Account' link for find Admin API Token.
+8. Visit https://YOUR_SITE_DOMAIN/sign-up and create new account.
+9. Fill data in "Project Branding: APINF Configuration Wizard".
+10. Fill data in "Settings for API Umbrella: APINF Configuration Wizard".
+* Host: "https://YOUR_SITE_DOMAIN:3002"
+* API Key: from step #5
+* Auth Token: from step #6
+* Base URL: "https://YOUR_SITE_DOMAIN:3002/api-umbrella/"
+* Elasticsearch: "http://YOUR_SITE_DOMAIN:14002"
+11. Add API backend https://YOUR_SITE_DOMAIN/api/new
+
 
 ## mail
 The mail object contains a username and password for the Mailgun service. You will need to register with Mailgun. Once registered, you can use your 'sandbox' domain credentials in a development environment or a custom domain in production:

--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -1,0 +1,25 @@
+# Developers can set up a local development environment
+# Full instructions https://github.com/apinf/api-umbrella-dashboard/blob/develop/CONTRIBUTING.md#development-installation-with-docker
+web:
+  build: .
+  dockerfile: ./docker/Dockerfile-development
+  ports:
+    - "3000:3000"
+  links:
+    - apiumbrella
+    - mongo
+  environment:
+    - MONGO_URL=mongodb://mongo/apinf_db
+    - ROOT_URL=http://apinf.dev:3000
+  volumes:
+    - .:/app:z
+apiumbrella:
+  image: nrel/api-umbrella:latest
+  volumes:
+    - ./docker/api-umbrella/config:/etc/api-umbrella
+  ports:
+    - "80:80"
+    - "443:443"
+    - "14002:14002"
+mongo:
+  image: mongo:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,48 @@
-# Developers can set up a local development environment
-# Full instructions https://github.com/apinf/api-umbrella-dashboard/blob/develop/CONTRIBUTING.md#development-installation-with-docker
-web:
-  build: .
-  dockerfile: ./docker/Dockerfile-development
-  ports:
-    - "3000:3000"
-  links:
-    - apiumbrella
-    - mongo
-  environment:
-    - MONGO_URL=mongodb://mongo/apinf_db
-    - ROOT_URL=http://apinf.dev:3000
-  volumes:
-    - .:/app:z
-apiumbrella:
-  image: nrel/api-umbrella:latest
-  volumes:
-    - ./docker/api-umbrella/config:/etc/api-umbrella
-  ports:
-    - "80:80"
-    - "443:443"
-    - "14002:14002"
-mongo:
-  image: mongo:latest
+version: '2'
+services:
+  apinf:
+    image: apinf/apinf
+    restart: always
+    env_file:
+      - 'docker/apinf/env'
+    environment:
+      - MONGO_URL=mongodb://mongo/apinf_db
+    ports:
+      - "3000:80"
+    depends_on:
+      - mongo
+  apiumbrella:
+    image: nrel/api-umbrella:0.11.1
+    restart: always
+    volumes:
+      - ./docker/api-umbrella/config:/etc/api-umbrella
+      - letsencrypt:/etc/letsencrypt
+    ports:
+      - "3001:3001"
+      - "3002:3002"
+      - "14002:14002"
+    depends_on:
+      - ssl
+  mongo:
+    restart: always
+    image: mongo:latest
+  ssl:
+    restart: always
+    image: opencapacity/lets-nginx:1.3
+    env_file:
+      - 'docker/ssl/env'
+    environment:
+      - UPSTREAM=apinf:80
+    ports:
+      - "443:443"
+      - "80:80"
+    volumes:
+      - letsencrypt:/etc/letsencrypt
+      - letsencrypt_backups:/var/lib/letsencrypt
+      - dhparam_cache:/cache
+    depends_on:
+      - apinf
+volumes:
+    letsencrypt: {}
+    letsencrypt_backups: {}
+    dhparam_cache: {}

--- a/docker/api-umbrella/config/api-umbrella.yml.example
+++ b/docker/api-umbrella/config/api-umbrella.yml.example
@@ -1,3 +1,5 @@
+http_port: 3001
+https_port: 3002
 services:
   - general_db
   - log_db
@@ -27,3 +29,8 @@ nginx:
   workers: 4
 gatekeeper:
   workers: 4
+hosts:
+  - hostname: example.com
+    default: true
+    ssl_cert: /etc/letsencrypt/live/example.com/fullchain.pem
+    ssl_cert_key: /etc/letsencrypt/live/example.com/privkey.pem

--- a/docker/apinf/env.example
+++ b/docker/apinf/env.example
@@ -1,0 +1,1 @@
+ROOT_URL=https://example.com

--- a/docker/ssl/env.example
+++ b/docker/ssl/env.example
@@ -1,0 +1,2 @@
+DOMAIN=example.com
+EMAIL=john.doe@example.com


### PR DESCRIPTION
Closes #1227

* Add docker-compose.yml for production.
* Add Docker-compose instructions.

Requires https://github.com/apinf/api-umbrella-dashboard/issues/1216