### PR TITLE
Fix disable API key field

### DIFF
--- a/apis/collection/backend.js
+++ b/apis/collection/backend.js
@@ -5,6 +5,17 @@ SimpleSchema.RegEx.Port = new RegExp(/^[0-9]{1,5}$/);
 SimpleSchema.RegEx.Prefix = new RegExp(/^\/[a-z0-9A-Z_\-\/]*$/);
 
 Schemas.Settings = new SimpleSchema({
+  disable_api_key: {
+    type: String,
+    optional: true,
+    label: 'API key options',
+    defaultValue: 'inherit',
+    allowedValues: [
+      'inherit',
+      'required',
+      'disabled'
+    ],
+  },
   default_response_headers_string: {
     type: String,
     optional: true,
@@ -16,8 +27,7 @@ Schemas.Settings = new SimpleSchema({
     optional: true,
     label: 'Override Response Headers',
     defaultValue: 'Access-Control-Allow-Origin: *',
-  },
-
+  }
 });
 
 Schemas.ApiBackendsSchema = new SimpleSchema({
@@ -191,10 +201,6 @@ Schemas.ApiBackendsSchema = new SimpleSchema({
     type: Date,
     optional: true
   },
-  disable_api_key: {
-    type: Boolean,
-    optional: true
-  },
   api_key_verification_level: {
     type: String,
     optional: true,
@@ -203,7 +209,7 @@ Schemas.ApiBackendsSchema = new SimpleSchema({
       'Required - API keys are mandatory',
       'Disabled - API keys are optional'
     ],
-    label: 'API Key Checks'
+    label: 'API Key Verification Level'
   },
   api_key_verification_transition_start_at: {
     type: Date,

--- a/apis/collection/backend.js
+++ b/apis/collection/backend.js
@@ -6,15 +6,10 @@ SimpleSchema.RegEx.Prefix = new RegExp(/^\/[a-z0-9A-Z_\-\/]*$/);
 
 Schemas.Settings = new SimpleSchema({
   disable_api_key: {
-    type: String,
+    type: Boolean,
     optional: true,
-    label: 'API key options',
-    defaultValue: 'inherit',
-    allowedValues: [
-      'inherit',
-      'required',
-      'disabled'
-    ],
+    label: 'Require API Key',
+    defaultValue: false
   },
   default_response_headers_string: {
     type: String,

--- a/apis/collection/backend.js
+++ b/apis/collection/backend.js
@@ -8,7 +8,7 @@ Schemas.Settings = new SimpleSchema({
   disable_api_key: {
     type: Boolean,
     optional: true,
-    label: 'Require API Key',
+    label: 'Disable API Key',
     defaultValue: false
   },
   default_response_headers_string: {

--- a/apis/collection/backend.js
+++ b/apis/collection/backend.js
@@ -8,8 +8,8 @@ Schemas.Settings = new SimpleSchema({
   disable_api_key: {
     type: Boolean,
     optional: true,
-    label: 'Disable API Key',
-    defaultValue: false
+    label: 'Require API Key',
+    defaultValue: true
   },
   default_response_headers_string: {
     type: String,


### PR DESCRIPTION
Closes #622 

## Proposed changes
- fix form to have "disable_api_key" under Settings object & correct field type (Boolean -> String)
- allow 3 options that Umbrella expects for "disable_api_key" field