### PR TITLE
Update API Umbrella Docker image version.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     depends_on:
       - mongo
   apiumbrella:
-    image: nrel/api-umbrella:0.11.1
+    image: nrel/api-umbrella:0.12.0
     restart: always
     volumes:
       - ./docker/api-umbrella/config:/etc/api-umbrella


### PR DESCRIPTION
Update API Umbrella Docker image version https://hub.docker.com/r/nrel/api-umbrella/tags/

Was tested on https://apinf3.usubov.com