### PR TITLE
Update MongoDB to version 3.2.6 and wiredTiger engine.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,8 @@ services:
       - ssl
   mongo:
     restart: always
-    image: mongo:latest
+    image: mongo:3.2.6
+    command: --storageEngine wiredTiger
   ssl:
     restart: always
     image: opencapacity/lets-nginx:1.3


### PR DESCRIPTION
- Update docker-compose.yml for use specific version of MongoDB with "wiredTiger" engine.
- Tested migration of data after upgrade. We no need do migration because previously docker-compose used "wiredTiger" engine. BTW I did backup of MongoDB on all our servers.

Closes #1410